### PR TITLE
Add meta descriptions and OG tags for The Rabbit

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8" />
   <title>Bricks First Publishing</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Bricks First Publishing offers inspiring books to build the life you were made to live." />
+  <meta property="og:title" content="The Rabbit" />
+  <meta property="og:description" content="A heartwarming tale about courage and friendship." />
+  <meta property="og:image" content="images/The-Rabbit-Book-Cover.png" />
+  <meta property="og:url" content="https://bricksfirst.com/shop.html#the-rabbit" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet" />

--- a/shop.html
+++ b/shop.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <title>Shop - Bricks First Publishing</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Explore books like The Rabbit from Bricks First Publishing." />
+  <meta property="og:title" content="The Rabbit" />
+  <meta property="og:description" content="A heartwarming tale about courage and friendship." />
+  <meta property="og:image" content="images/The-Rabbit-Book-Cover.png" />
+  <meta property="og:url" content="https://bricksfirst.com/shop.html#the-rabbit" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add meta description tags to pages
- include Open Graph metadata referencing **The Rabbit** for sharing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c516937dc832fb833a4d356836917