### PR TITLE
Update README with live site URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ For a hosted preview, the repository is configured to work with **GitHub Pages**
    the source.
 3. GitHub will provide a URL where the site is automatically deployed after each push.
 
+## Live Site
+
+You can view the published website at [https://bricksfirst.com](https://bricksfirst.com). The site serves the landing page from `index.html`, the shop page from [`shop.html`](https://bricksfirst.com/shop.html), and includes a custom [`404.html`](https://bricksfirst.com/404.html) for unknown URLs.
+
 ## Updating Content
 
 All of the website files live at the repository root:


### PR DESCRIPTION
## Summary
- document the public URL in a new Live Site section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c59cb5540832faa7ee046d9704a9a