### PR TITLE
Add About page and update navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,6 +13,7 @@
       <ul class="nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="shop.html">Shop</a></li>
+        <li><a href="about.html">About</a></li>
       </ul>
     </nav>
     <header class="hero shop-hero">

--- a/about.html
+++ b/about.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>About - Bricks First Publishing</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="images/Bricks-First-Logo-Design.png" type="image/png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="navbar">
+    <a href="index.html"><img src="images/Bricks-First-Logo-Design.png" alt="Bricks First Publishing logo" class="logo" /></a>
+    <ul class="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="shop.html">Shop</a></li>
+      <li><a href="about.html" class="active">About</a></li>
+    </ul>
+  </nav>
+  <header class="hero about-hero">
+    <h1>About Us</h1>
+  </header>
+  <main class="main-content">
+    <section class="release-banner">
+      <img src="images/The-Craft-Of-Storytelling.png" alt="Stack of books">
+      <div class="release-info">
+        <h2>Our Mission</h2>
+        <p>Bricks First Publishing delivers inspiring books that help you build the life you were made to live.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="copyright-year"></span> Bricks First Publishing</p>
+  </footer>
+  <script>
+    document.getElementById('copyright-year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       <ul class="nav-links">
         <li><a href="index.html" class="active">Home</a></li>
         <li><a href="shop.html">Shop</a></li>
+        <li><a href="about.html">About</a></li>
       </ul>
     </nav>
     <main>

--- a/shop.html
+++ b/shop.html
@@ -28,6 +28,7 @@
       <ul class="nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="shop.html" class="active">Shop</a></li>
+        <li><a href="about.html">About</a></li>
       </ul>
     </nav>
     <header class="hero shop-hero">

--- a/style.css
+++ b/style.css
@@ -61,6 +61,13 @@ body, html {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
 
+.about-hero {
+  min-height: 40vh;
+  background: url('images/The-Craft-Of-Storytelling.png') center/cover no-repeat;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
 .hero h1 {
   font-family: 'Playfair Display', serif;
   font-size: 2.5rem;


### PR DESCRIPTION
## Summary
- add new About page describing Bricks First Publishing's mission
- add `about.html` link to the site navigation
- support the new page with an `.about-hero` style

## Testing
- `htmlhint` *(fails: command not found)*
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5fc20a70832f9e8bb38a26d23001