### PR TITLE
Add simple blog page

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,6 +14,7 @@
         <li><a href="index.html">Home</a></li>
         <li><a href="shop.html">Shop</a></li>
         <li><a href="about.html">About</a></li>
+        <li><a href="blog.html">Blog</a></li>
       </ul>
     </nav>
     <header class="hero shop-hero">

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a hosted preview, the repository is configured to work with **GitHub Pages**
 
 ## Live Site
 
-You can view the published website at [https://bricksfirst.com](https://bricksfirst.com). The site serves the landing page from `index.html`, the shop page from [`shop.html`](https://bricksfirst.com/shop.html), and includes a custom [`404.html`](https://bricksfirst.com/404.html) for unknown URLs.
+You can view the published website at [https://bricksfirst.com](https://bricksfirst.com). The site serves the landing page from `index.html`, the shop page from [`shop.html`](https://bricksfirst.com/shop.html), the blog from [`blog.html`](https://bricksfirst.com/blog.html), and includes a custom [`404.html`](https://bricksfirst.com/404.html) for unknown URLs.
 
 ## Updating Content
 
@@ -25,6 +25,7 @@ All of the website files live at the repository root:
 
 - `index.html` – landing page with release information
 - `shop.html` – simple shop/coming-soon page
+- `blog.html` – latest news and updates
 - `images/` – folder containing images such as book covers
 - `style.css` – styling for all pages
 

--- a/blog.html
+++ b/blog.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>About - Bricks First Publishing</title>
+  <title>Blog - Bricks First Publishing</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="images/Bricks-First-Logo-Design.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -16,21 +16,19 @@
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="shop.html">Shop</a></li>
-      <li><a href="about.html" class="active">About</a></li>
-      <li><a href="blog.html">Blog</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="blog.html" class="active">Blog</a></li>
     </ul>
   </nav>
-  <header class="hero about-hero">
-    <h1>About Us</h1>
+  <header class="hero blog-hero">
+    <h1>Blog</h1>
   </header>
   <main class="main-content">
-    <section class="release-banner">
-      <img src="images/The-Craft-Of-Storytelling.png" alt="Stack of books">
-      <div class="release-info">
-        <h2>Our Mission</h2>
-        <p>Bricks First Publishing delivers inspiring books that help you build the life you were made to live.</p>
-      </div>
-    </section>
+    <article class="blog-post">
+      <h2>Welcome to Our New Blog</h2>
+      <p class="post-date">April 1, 2024</p>
+      <p>We're excited to share updates, behind-the-scenes stories, and writing tips. Stay tuned for more posts soon!</p>
+    </article>
   </main>
   <footer>
     <p>&copy; <span id="copyright-year"></span> Bricks First Publishing</p>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <li><a href="index.html" class="active">Home</a></li>
         <li><a href="shop.html">Shop</a></li>
         <li><a href="about.html">About</a></li>
+        <li><a href="blog.html">Blog</a></li>
       </ul>
     </nav>
     <main>
@@ -47,6 +48,11 @@
         <h2>Stay in the Loop</h2>
         <p>Get updates on new releases and special offers.</p>
         <a href="mailto:info@bricksfirst.com?subject=Subscribe" class="btn">Join Mailing List</a>
+      </section>
+      <section class="blog-promo">
+        <h2>From the Blog</h2>
+        <p>Read the latest news and writing tips.</p>
+        <a href="blog.html" class="btn">Visit Blog</a>
       </section>
     </main>
   <footer>

--- a/shop.html
+++ b/shop.html
@@ -29,6 +29,7 @@
         <li><a href="index.html">Home</a></li>
         <li><a href="shop.html" class="active">Shop</a></li>
         <li><a href="about.html">About</a></li>
+        <li><a href="blog.html">Blog</a></li>
       </ul>
     </nav>
     <header class="hero shop-hero">

--- a/style.css
+++ b/style.css
@@ -68,6 +68,13 @@ body, html {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
 
+.blog-hero {
+  min-height: 40vh;
+  background: url('images/study-desk-picture.png') center/cover no-repeat;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
 .hero h1 {
   font-family: 'Playfair Display', serif;
   font-size: 2.5rem;
@@ -126,6 +133,16 @@ body, html {
   margin-bottom: 1rem;
 }
 
+.blog-promo {
+  text-align: center;
+  padding: 2rem 1.5rem;
+}
+
+.blog-promo h2 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 1rem;
+}
+
 .release-banner h2 {
   font-family: 'Playfair Display', serif;
   font-size: 1.5rem;
@@ -141,6 +158,23 @@ footer {
 .main-content {
   text-align: center;
   padding: 2rem;
+}
+
+.blog-post {
+  max-width: 800px;
+  margin: 0 auto 2rem;
+  text-align: left;
+}
+
+.blog-post h2 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 0.5rem;
+}
+
+.blog-post .post-date {
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 1rem;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- create `blog.html`
- link to blog in navigation on all pages
- add blog promotion section on homepage
- style new blog elements
- document blog page in README

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c60943028832fadc29267dcad139c