### PR TITLE
Add nav-toggle focus outline

### DIFF
--- a/style.css
+++ b/style.css
@@ -284,6 +284,14 @@ footer {
   cursor: pointer;
 }
 
+/* Visible outline when hamburger menu receives focus */
+.nav-toggle:focus,
+.nav-toggle:focus-visible {
+  background-color: transparent;
+  outline: 2px solid #c53030;
+  outline-offset: 2px;
+}
+
 .nav-toggle span,
 .nav-toggle span::before,
 .nav-toggle span::after {


### PR DESCRIPTION
## Summary
- highlight nav toggle when it receives keyboard focus

## Testing
- `node test_nav_toggle.js` *(fails without --no-sandbox; updated script)*
- `node test_nav_toggle.js`

------
https://chatgpt.com/codex/tasks/task_e_684d982ef504832f995afdf9191cbf17