### PR TITLE
Add home page About section

### DIFF
--- a/images/bricks-placeholder.svg
+++ b/images/bricks-placeholder.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <rect width="600" height="300" fill="#f0f0f0"/>
+  <rect x="60" y="200" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="200" y="200" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="340" y="200" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="480" y="200" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="130" y="150" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="270" y="150" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="410" y="150" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="200" y="100" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+  <rect x="340" y="100" width="120" height="50" fill="#b5651d" stroke="#8b4513"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,11 @@
         <h1>Books That Build the Life You Were Made to Live</h1>
         <a href="shop.html" class="btn">Shop Now</a>
       </header>
+      <section class="about-preview">
+        <img loading="lazy" src="images/bricks-placeholder.svg" alt="Illustration of stacked bricks" />
+        <h2>Our Vision</h2>
+        <p>Bricks First Publishing was founded by Cole Thomas Sommi to create books that help people build better lives—brick by brick. We publish works that inspire, challenge, and transform.</p>
+      </section>
       <section class="release-banner">
         <img loading="lazy" src="images/The-Rabbit-Book-Cover.png" alt="Cover of The Rabbit book" />
         <div class="release-info">

--- a/style.css
+++ b/style.css
@@ -168,6 +168,23 @@ a:focus {
   margin-bottom: 0;
 }
 
+.about-preview {
+  text-align: center;
+  padding: 2rem 1.5rem;
+}
+
+.about-preview h2 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 1rem;
+}
+
+.about-preview img {
+  width: 80%;
+  max-width: 250px;
+  height: auto;
+  margin-bottom: 1rem;
+}
+
 .subscribe {
   text-align: center;
   padding: 2rem 1.5rem;


### PR DESCRIPTION
## Summary
- expand homepage with new About Us section
- provide placeholder bricks illustration
- style the new section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9dcf5768832f9778c29b62eed586