### PR TITLE
Add global hero overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,6 +60,8 @@ body, html {
 }
 
 .hero {
+  position: relative;
+  overflow: hidden;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -67,6 +69,22 @@ body, html {
   align-items: center;
   text-align: center;
   padding: 0 1.5rem;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4));
+  z-index: 0;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
 }
 
 .home-hero {


### PR DESCRIPTION
## Summary
- add gradient overlay to hero sections via `::before`
- ensure hero content stays in front of the overlay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684da3b5d7b8832fbe946f72ca1545f7