### PR TITLE
Improve heading font scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -128,7 +128,7 @@ body, html {
 
 .hero h1 {
   font-family: 'Playfair Display', serif;
-  font-size: 2.5rem;
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
   font-weight: 700;
   margin-bottom: 1.5rem;
 }
@@ -237,6 +237,7 @@ a:focus {
 
 .subscribe h2 {
   font-family: 'Playfair Display', serif;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
   margin-bottom: 1rem;
 }
 
@@ -292,7 +293,7 @@ a:focus {
 
 .release-banner h2 {
   font-family: 'Playfair Display', serif;
-  font-size: 1.5rem;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
   margin: 0 0 1rem;
 }
 
@@ -368,9 +369,6 @@ footer {
 }
 
 @media (min-width: 768px) {
-  .hero h1 {
-    font-size: 3.5rem;
-  }
   .release-banner {
     flex-direction: row;
     text-align: left;
@@ -380,12 +378,6 @@ footer {
     max-width: 250px;
     width: 250px;
     margin-right: 2rem;
-  }
-  .release-banner h2 {
-    font-size: 2rem;
-  }
-  .subscribe h2 {
-    font-size: 2rem;
   }
 }
 /* Sticky navigation bar */


### PR DESCRIPTION
## Summary
- scale `.hero h1` size using `clamp()`
- scale `.release-banner h2` and `.subscribe h2` with `clamp()`
- remove old responsive font overrides

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da450fdf0832fa3747d451cd1381a